### PR TITLE
Enable p-s-a over d-s-a

### DIFF
--- a/openstates/settings/base.py
+++ b/openstates/settings/base.py
@@ -97,7 +97,7 @@ AUTHENTICATION_BACKENDS = (
 )
 
 SUNLIGHT_AUTH_BASE_URL = 'https://login.sunlightfoundation.com/'
-SOCIAL_AUTH_SUNLIGHT_KEY = 'testapp'
+SOCIAL_AUTH_SUNLIGHT_KEY = 'openstates'
 #SOCIAL_AUTH_SUNLIGHT_SECRET = 'set in local settings'
 SUNLIGHT_AUTH_SCOPE = []
 

--- a/openstates/settings/base.py
+++ b/openstates/settings/base.py
@@ -87,7 +87,7 @@ INSTALLED_APPS = (
     'billy.web.admin',
     'billy.web.public',
     'locksmith.mongoauth',
-    'social_auth',
+    'social.apps.django_app.default',
     'markup_tags',
     'funfacts',
 )
@@ -97,8 +97,8 @@ AUTHENTICATION_BACKENDS = (
 )
 
 SUNLIGHT_AUTH_BASE_URL = 'https://login.sunlightfoundation.com/'
-SUNLIGHT_AUTH_APP_ID = 'openstates'
-#SUNLIGHT_AUTH_SECRET = 'set in local settings'
+SOCIAL_AUTH_SUNLIGHT_KEY = 'testapp'
+#SOCIAL_AUTH_SUNLIGHT_SECRET = 'set in local settings'
 SUNLIGHT_AUTH_SCOPE = []
 
 LOGGING = {


### PR DESCRIPTION
Change was pushed into master after @jcarbaugh OKd and pushed the sfcom change live. Merged into data-dot, and djang-sunlightauth.

I tested this out locally, looked good. Doesn't need a re-deploy, but if we re-deploy master in the future, we'll get the wrong django-sunlightauth (because master is now p-s-a).
