### PR TITLE
DC's scoreupdated in report card

### DIFF
--- a/templates/flat/reportcard.html
+++ b/templates/flat/reportcard.html
@@ -75,7 +75,7 @@ $(document).ready(function() {
             <th class="sort sorting_asc" role="columnheader">Completeness</th>
             <th class="sort sorting_asc" role="columnheader">Timeliness</th>
             <th class="sort sorting_asc" role="columnheader">Ease of Access</th>
-            <th class="sort sorting_asc" role="columnheader">Machine Readibility</th>
+            <th class="sort sorting_asc" role="columnheader">Machine Readability</th>
             <th class="sort sorting_asc" role="columnheader">Standards</th>
             <th class="sort sorting_asc" role="columnheader">Permanence</th>
             <th class="sort sorting_asc" role="columnheader">Grade</th>
@@ -305,12 +305,12 @@ $(document).ready(function() {
         <tr>
             <td class="bold">District of Columbia </td>
             <td class="score-neutral" >0</td>
-            <td class="score-neutral" title="Multiple calls were not returned; data appears to be updated daily.">0</td>
-            <td class="score-neutral" >0</td>
-            <td class="score-neutral" >0</td>
+            <td class="score-good" >1</td>
+            <td class="score-bad" title="Extremely heavy reliance on Javascript." >-1</td>
+            <td class="score-bad" >-1</td>
             <td class="score-neutral" >0</td>
             <td class="score-good" title="Inpermanent legislator pages.">1</td>
-            <td class="grade grade-c">C</td>
+            <td class="grade grade-d">D</td>
         </tr>
 
         <tr>
@@ -716,6 +716,7 @@ $(document).ready(function() {
     <p>Virginia - On March 22nd, 2013 Virginia Legislature staff clarified their update policy, raising their score by a point and putting them into the 'A' class.  There is also potential that a coming change to their data availability will raise their score further.</p>
     <p>Colorado - On March 22nd, 2013 it was determined via discussion with an IT manager from the  Colorado Legislature that the bills that went missing were site errors and no actual data was affected.  This made a large change in Colorado's Timeliness score, raising Colorado from an F to a C.</p>
     <p>Pennsylvania - On December 4th, 2013 we evaluated the new Pennsylvania website that was unveiled in November 2013.  This resulted in an increase in the timeliness, ease of access, and machine readability scores.</p>
+    <p>District of Columbia - On March 24, 2015 we evaluated the new District of Columbia website. The result was a decrease in ease of access and machine readability scores, and an increase in timeliness, lowering DC from a C to a D.</p>
 
 </div>
 


### PR DESCRIPTION
also corrected the spelling of "readability" in the header
