### PR TITLE
show correct month on event page calendar

### DIFF
--- a/templates/billy/web/public/event.html
+++ b/templates/billy/web/public/event.html
@@ -18,7 +18,7 @@ $(document).ready(function() {
   $.pjax.defaults.scrollTo = false;
 
   // Initialize the calendar.
-  $("#calendar").calendarWidget({month: {{event.when.month}},
+  $("#calendar").calendarWidget({month: {{event.when.month}}-1,
                                  year: {{event.when.year}}});
 
   // Kill the unused nav buttons.


### PR DESCRIPTION
javascript dates start counting month numbers at zero. python at 1. It took me 2 hours to track down this 2-character fix :(
