### PR TITLE
Fix steps required to start a dev instance in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -3,6 +3,6 @@ Running openstates.org Locally
 
 - Navigate to the `openstates.org` directory
 - Invoke the `openstates` virtualenv (most importantly Django 1.8 and Python 2)
-- Set the SECRET_KEY environment variable to anything, it just can't be missing
-- Run `python manage.py runserver —-settings openstates.settings.dev`
+- Ensure that the MongoDB daemon process is running.
+- Run `python manage.py runserver`
 - View the website at `localhost:8000`


### PR DESCRIPTION
1. Ensure that `mongod` is running.
2. The `SECRET_KEY` env variable is no longer required.
3. `settings/dev.py` was deprecated.

Fixes #46