### PR TITLE
Twitter Card Integration

### DIFF
--- a/templates/billy/web/public/base.html
+++ b/templates/billy/web/public/base.html
@@ -11,6 +11,12 @@
     <meta property="og:type" content="cause">
     <meta property="og:image" content="{% static 'images/fbshare.jpg' %}">
     <meta property="og:site_name" content="Open States">
+
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:site" content="@openstates">
+    <meta name="twitter:title" content="Open States">
+    <meta name="twitter:description" content="{% trans 'Follow politics in your state legislature. Find your legislators, see how they vote and browse bills, committees and events.' %}">
+    <meta name="twitter:image" content="{% static 'images/fbshare.jpg' %}">
     {% endblock %}
     <link rel="stylesheet" type="text/css" href="{% static 'css/main.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'select2-2.0/select2.css' %}"/>

--- a/templates/billy/web/public/base.html
+++ b/templates/billy/web/public/base.html
@@ -7,9 +7,11 @@
     <title>{% striptags %}{% block title %}{% endblock %}{% end_striptags %} - Open States</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="description" content="{% block description %}{% endblock %}">
+    {% block metablock %}
     <meta property="og:type" content="cause">
     <meta property="og:image" content="{% static 'images/fbshare.jpg' %}">
     <meta property="og:site_name" content="Open States">
+    {% endblock %}
     <link rel="stylesheet" type="text/css" href="{% static 'css/main.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'select2-2.0/select2.css' %}"/>
 

--- a/templates/billy/web/public/bill.html
+++ b/templates/billy/web/public/bill.html
@@ -9,6 +9,14 @@
   {{bill.bill_id }} - {{metadata.display_name}} {{bill.session_details.display_name}}
 {% endblock %}
 
+{% block metablock %}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@openstates">
+<meta name="twitter:title" content="{{metadata.display_name}} {{bill.chamber_name}} {{bill.type_string|title}} {{bill.bill_id}} on Open States">
+<meta name="twitter:description" content="{{bill.title}}">
+{% endblock %}
+
+
 {% block description %}
 {{metadata.display_name}} {{bill.chamber_name}} {{bill.type_string|title}} {{bill.bill_id}}: {{bill.title}}.
 {% endblock %}

--- a/templates/billy/web/public/committee.html
+++ b/templates/billy/web/public/committee.html
@@ -2,11 +2,20 @@
 {% load i18n %}
 {% load humanize %}
 {% load customtags %}
-
+{% load static from staticfiles %}
 
 {% block title %}
  {{committee.display_name}} ({{committee.chamber_name}}) -
   {{metadata.legislature_name}}
+{% endblock %}
+
+{% block metablock %}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@openstates">
+<meta name="twitter:title" content="{{ metadata.legislature_name }} - {{ committee.display_name }} {% trans 'Committee' %}">
+<meta name="twitter:description" content="Learn more about the {{ metadata.legislature_name }} {{committee.chamber_name}} {{committee.display_name}} {% trans 'Committee' %} at Open States">
+<meta name="twitter:image" content="{% static 'images/fbshare.jpg' %}">
+
 {% endblock %}
 
 {% block description %}

--- a/templates/billy/web/public/homepage.html
+++ b/templates/billy/web/public/homepage.html
@@ -5,6 +5,16 @@
 
 {% block title %}{% trans "Open States: discover politics in your state" %}{% endblock %}
 {% block description %}{% trans "Follow politics in your state legislature. Find your legislators, see how they vote and browse bills, committees and events." %} {% endblock %}
+
+{% block metablock %}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@openstates">
+<meta name="twitter:title" content="Open States">
+<meta name="twitter:description" content="{% trans 'Follow politics in your state legislature. Find your legislators, see how they vote and browse bills, committees and events.' %}">
+<meta name="twitter:image" content="{% static 'images/fbshare.jpg' %}">
+{% endblock %}
+
+
 {% block share_options %} data-twitter-options="title=Open%20States:%20discover%20politics%20in%20your%20state%20with%20@OpenStates%20from%20@openstates" {% endblock %}
 
 {% block headblock %}

--- a/templates/billy/web/public/legislator.html
+++ b/templates/billy/web/public/legislator.html
@@ -5,6 +5,14 @@
 {% load humanize %}
 {% load customtags %}
 
+{% block metablock %}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@openstates">
+<meta name="twitter:title" content="{{legislator.full_name }}">
+<meta name="twitter:description" content="{{metadata.legislature_name}} &mdash; {% if legislator.active %} {{legislator.party}} &mdash; {{legislator.title}} &mdash; {# if first character of district is numeric, add 'District' #} from {% if legislator.district.0.isdigit %} {% trans 'District' %} {% endif %}{{legislator.district}} {% else %} {{legislator.full_name}} {% trans 'no longer serves in the' %} {{metadata.legislature_name}}.{% endif %} on Open States">
+<meta name="twitter:image" content="https://s.openstates.org/photos/small/{{legislator.leg_id}}.jpg">
+
+{% endblock %}
 
 {% block title %}
   {{legislator.full_name }} -

--- a/templates/billy/web/public/legislators.html
+++ b/templates/billy/web/public/legislators.html
@@ -2,8 +2,18 @@
 {% load staticfiles %}
 {% load i18n %}
 {% load customtags %}
+{% load static from staticfiles %}
 
 {% block title %}{{metadata.name}} {{ chamber_title }}{% endblock %}
+
+{% block metablock %}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@openstates">
+<meta name="twitter:title" content="{{ metadata.name }} {{chamber_title}} on Open States">
+<meta name="twitter:description" content="Learn more about {{ metadata.name }} {{chamber_title}} at Open States">
+<meta name="twitter:image" content="{% static 'images/fbshare.jpg' %}">
+
+{% endblock %}
 
 {% block description %}{{chamber_title}} {% trans "currently serving in" %} {{metadata.name}} {% endblock %}
 

--- a/templates/billy/web/public/region.html
+++ b/templates/billy/web/public/region.html
@@ -3,9 +3,19 @@
 {% load staticfiles %}
 {% load i18n %}
 {# load funfacts #}
+{% load static from staticfiles %}
 
 {% block title %}{{metadata.legislature_name}}{% endblock %}
 {% block description %}{{metadata.legislature_name}}: {% trans "Keep up to date with bills, legislators, votes, committees and events." %} {% endblock %}
+
+{% block metablock %}
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@openstates">
+<meta name="twitter:title" content="The {{metadata.legislature_name}} on Open States">
+<meta name="twitter:description" content="{{metadata.legislature_name}}: {% trans 'Keep up to date with bills, legislators, votes, committees and events' %} at Open States">
+<meta name="twitter:image" content="{% static 'images/fbshare.jpg' %}">
+
+{% endblock %}
 
 {% block bodyclass %}{% endblock %}
 


### PR DESCRIPTION
Pull Request for Issue #48 

This pull request adds a new block in base.html which includes default meta tags for any template that doesn't override them.

Additionally, it adds specific implementations (generally based off of the descriptions on the pages) for:

* Bill
* Committee
* Homepage
* Legislator
* Legislators
* Region

You can view the cards by visiting https://cards-dev.twitter.com/validator (and using something like https://github.com/localtunnel/localtunnel if you are running the server locally).

I'd appreciate any feedback on the content (such as what might be more relevant to showcase on particular templates) or other templates that seem important enough to add custom content to. Otherwise, I can also add the og tags for each template as well.